### PR TITLE
Add `{input}` placeholder for interactive user input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /doc/tags
 foo.*
 tt.*
+tmp_*
+.tmp_*

--- a/README.md
+++ b/README.md
@@ -287,6 +287,30 @@ require("wiremux").setup({
 })
 ```
 
+### Interactive input
+
+The `{input}` placeholder prompts the user via `vim.ui.input()` before sending. Use it when part of the text needs to come from the user at send time.
+
+| Syntax                    | Prompt label   | Default value |
+| ------------------------- | -------------- | ------------- |
+| `{input}`                 | "Input"        | —             |
+| `{input:Search query}`    | "Search query" | —             |
+| `{input:Query:foo bar}`   | "Query"        | `foo bar`     |
+| `{input:URL:http://example.com}` | "URL" | `http://example.com` |
+
+```lua
+-- Basic usage
+require("wiremux").send("question:\n{input:Question}\n\ncontext:\n{this}")
+
+-- Single input with a default value
+require("wiremux").send("grep -r '{input:Search query:TODO}' {file}")
+
+-- Multiple distinct inputs in one send
+require("wiremux").send("git log --author='{input:Author}' --grep='{input:Grep pattern}'")
+```
+
+All sync placeholders (`{file}`, `{selection}`, etc.) resolve first, then each `{input}` prompts in order. Cancelling any prompt aborts the entire send. Text entered by the user is sent as-is — placeholders typed into the prompt are **not** expanded.
+
 ## Target Resolution
 
 When you trigger an action (send, toggle, etc.), wiremux resolves which targets to use. Four options control this: **target**, **behavior**, **mode**, and **filters**.

--- a/doc/wiremux.txt
+++ b/doc/wiremux.txt
@@ -505,6 +505,31 @@ This is useful for conditional visibility in SendItem:
   }
 <
 
+Interactive input ~
+                                                              *wiremux-input*
+The `{input}` placeholder prompts the user via `vim.ui.input()` at send
+time. Use it when part of the text needs to come from the user.
+
+  {input}                 prompt with label "Input", no default
+  {input:Search query}    prompt with label "Search query"
+  {input:Query:foo bar}   prompt with label "Query", default "foo bar"
+  {input:URL:http://example.com}  prompt "URL", default "http://example.com"
+
+>lua
+  -- Single input with a default value
+  require("wiremux").send("grep -r '{input:Search query:TODO}' {file}")
+
+  -- Multiple distinct inputs in one send
+  require("wiremux").send(
+    "git log --author='{input:Author}' --grep='{input:Grep pattern}'"
+  )
+<
+
+All sync placeholders resolve first, then each `{input}` prompts in
+order. Identical `{input}` expressions are deduplicated (prompted once,
+reused everywhere). Cancelling any prompt aborts the entire send.
+Placeholders typed into the prompt are sent as literal text (not expanded).
+
 ==============================================================================
 6. COMMANDS                                                      *wiremux-commands*
 

--- a/lua/wiremux/context/init.lua
+++ b/lua/wiremux/context/init.lua
@@ -54,6 +54,7 @@ function M.expand(text)
 	local cache = {}
 	return (
 		text:gsub("{([%w_]+)}", function(var)
+			if var == "input" then return nil end
 			if cache[var] == nil then
 				cache[var] = M.get(var)
 			end

--- a/lua/wiremux/context/input.lua
+++ b/lua/wiremux/context/input.lua
@@ -1,0 +1,112 @@
+local M = {}
+
+---Parse an input key into prompt and default value
+---Key formats: "input", "input:Prompt", "input:Prompt:default"
+---@param key string The full key (e.g. "input:Branch:main")
+---@return string prompt
+---@return string? default
+function M.parse(key)
+    if key == "input" then
+        return "Input", nil
+    end
+
+    -- Strip "input:" prefix
+    local rest = key:sub(#"input:" + 1)
+
+    -- Find first colon for prompt:default split
+    local colon_pos = rest:find(":", 1, true)
+    if not colon_pos then
+        return rest, nil
+    end
+
+    local prompt = rest:sub(1, colon_pos - 1)
+    local default = rest:sub(colon_pos + 1)
+
+    return prompt, default
+end
+
+---Find all unique input placeholder keys in text
+---Returns keys in order of first appearance
+---@param text string
+---@return string[]
+function M.find(text)
+    if not text:find("{input", 1, true) then
+        return {}
+    end
+
+    local seen = {}
+    local keys = {}
+
+    -- Match {input...} placeholders — capture everything between { and }
+    for content in text:gmatch("{(input[^}]*)}") do
+        -- Reject names like {input_var} or {input2} — only allow bare "input" or "input:..."
+        if content == "input" or content:sub(1, 6) == "input:" then
+            if not seen[content] then
+                seen[content] = true
+                table.insert(keys, content)
+            end
+        end
+    end
+
+    return keys
+end
+
+---Quick check if text contains any input placeholders
+---@param text string
+---@return boolean
+function M.has_inputs(text)
+    return #M.find(text) > 0
+end
+
+---Replace input placeholders in text with resolved values
+---Only replaces placeholders whose keys exist in the values table
+---@param text string
+---@param values table<string, string>
+---@return string
+function M.replace(text, values)
+    return text:gsub("{(input[^}]*)}", function(content)
+        if content == "input" or content:sub(1, 6) == "input:" then
+            if values[content] ~= nil then
+                return values[content]
+            end
+        end
+        -- Leave non-input or unresolved placeholders intact
+        return "{" .. content .. "}"
+    end)
+end
+
+---Resolve input placeholders by chaining vim.ui.input() calls
+---Calls on_done(values) with a table of key→value, or on_done(nil) if user cancels
+---@param keys string[] Unique input keys to resolve
+---@param on_done fun(values: table<string, string>|nil)
+function M.resolve(keys, on_done)
+    local values = {}
+    local i = 0
+
+    local function next_input()
+        i = i + 1
+        if i > #keys then
+            on_done(values)
+            return
+        end
+
+        local key = keys[i]
+        local prompt, default = M.parse(key)
+
+        vim.ui.input({
+            prompt = prompt .. ": ",
+            default = default or "",
+        }, function(value)
+            if value == nil then
+                on_done(nil)
+                return
+            end
+            values[key] = value
+            next_input()
+        end)
+    end
+
+    next_input()
+end
+
+return M

--- a/tests/context_input_spec.lua
+++ b/tests/context_input_spec.lua
@@ -1,0 +1,232 @@
+---@module 'luassert'
+
+describe("context.input", function()
+    local input
+
+    before_each(function()
+        package.loaded["wiremux.context.input"] = nil
+        input = require("wiremux.context.input")
+    end)
+
+    describe("parse", function()
+        it("returns default prompt for bare input", function()
+            local prompt, default = input.parse("input")
+            assert.are.equal("Input", prompt)
+            assert.is_nil(default)
+        end)
+
+        it("returns custom prompt without default", function()
+            local prompt, default = input.parse("input:Enter branch name")
+            assert.are.equal("Enter branch name", prompt)
+            assert.is_nil(default)
+        end)
+
+        it("returns prompt and default", function()
+            local prompt, default = input.parse("input:Branch:main")
+            assert.are.equal("Branch", prompt)
+            assert.are.equal("main", default)
+        end)
+
+        it("handles default with colons", function()
+            local prompt, default = input.parse("input:URL:http://localhost:8080")
+            assert.are.equal("URL", prompt)
+            assert.are.equal("http://localhost:8080", default)
+        end)
+    end)
+
+    describe("find", function()
+        it("returns empty for text without input placeholders", function()
+            local keys = input.find("echo hello {file}")
+            assert.are.equal(0, #keys)
+        end)
+
+        it("finds bare {input}", function()
+            local keys = input.find("echo {input}")
+            assert.are.equal(1, #keys)
+            assert.are.equal("input", keys[1])
+        end)
+
+        it("finds {input:prompt}", function()
+            local keys = input.find("git checkout {input:Branch}")
+            assert.are.equal(1, #keys)
+            assert.are.equal("input:Branch", keys[1])
+        end)
+
+        it("finds {input:prompt:default}", function()
+            local keys = input.find("git checkout {input:Branch:main}")
+            assert.are.equal(1, #keys)
+            assert.are.equal("input:Branch:main", keys[1])
+        end)
+
+        it("deduplicates same placeholder", function()
+            local keys = input.find("{input} and {input}")
+            assert.are.equal(1, #keys)
+            assert.are.equal("input", keys[1])
+        end)
+
+        it("finds multiple distinct inputs", function()
+            local keys = input.find("mv {input:Source} {input:Destination}")
+            assert.are.equal(2, #keys)
+            assert.are.equal("input:Source", keys[1])
+            assert.are.equal("input:Destination", keys[2])
+        end)
+
+        it("ignores non-input placeholders like {input_var}", function()
+            local keys = input.find("{input_var} and {input}")
+            assert.are.equal(1, #keys)
+            assert.are.equal("input", keys[1])
+        end)
+
+        it("ignores {input2} style names", function()
+            local keys = input.find("{input2} test")
+            assert.are.equal(0, #keys)
+        end)
+    end)
+
+    describe("has_inputs", function()
+        it("returns false for plain text", function()
+            assert.is_false(input.has_inputs("no placeholders"))
+        end)
+
+        it("returns false for non-input placeholders", function()
+            assert.is_false(input.has_inputs("{file} and {line}"))
+        end)
+
+        it("returns true for bare input", function()
+            assert.is_true(input.has_inputs("echo {input}"))
+        end)
+
+        it("returns true for input with prompt", function()
+            assert.is_true(input.has_inputs("{input:Name}"))
+        end)
+    end)
+
+    describe("replace", function()
+        it("replaces bare input", function()
+            local result = input.replace("echo {input}", { input = "hello" })
+            assert.are.equal("echo hello", result)
+        end)
+
+        it("replaces input with prompt", function()
+            local result = input.replace("git checkout {input:Branch}", { ["input:Branch"] = "develop" })
+            assert.are.equal("git checkout develop", result)
+        end)
+
+        it("replaces duplicate placeholders", function()
+            local result = input.replace("{input} and {input}", { input = "val" })
+            assert.are.equal("val and val", result)
+        end)
+
+        it("replaces multiple distinct inputs", function()
+            local result = input.replace("mv {input:From} {input:To}", {
+                ["input:From"] = "a.txt",
+                ["input:To"] = "b.txt",
+            })
+            assert.are.equal("mv a.txt b.txt", result)
+        end)
+
+        it("leaves unresolved input placeholders intact", function()
+            local result = input.replace("{input:A} {input:B}", { ["input:A"] = "resolved" })
+            assert.are.equal("resolved {input:B}", result)
+        end)
+
+        it("does not touch non-input placeholders", function()
+            local result = input.replace("{file} {input}", { input = "val" })
+            assert.are.equal("{file} val", result)
+        end)
+    end)
+
+    describe("resolve", function()
+        it("collects values from vim.ui.input", function()
+            local input_calls = {}
+            vim.ui.input = function(opts, callback)
+                table.insert(input_calls, opts)
+                callback("user_value")
+            end
+
+            local result
+            input.resolve({ "input" }, function(values)
+                result = values
+            end)
+
+            assert.are.equal(1, #input_calls)
+            assert.are.equal("Input: ", input_calls[1].prompt)
+            assert.are.equal("", input_calls[1].default)
+            assert.is_not_nil(result)
+            assert.are.equal("user_value", result["input"])
+        end)
+
+        it("passes prompt and default to vim.ui.input", function()
+            local input_calls = {}
+            vim.ui.input = function(opts, callback)
+                table.insert(input_calls, opts)
+                callback("val")
+            end
+
+            input.resolve({ "input:Branch:main" }, function() end)
+
+            assert.are.equal("Branch: ", input_calls[1].prompt)
+            assert.are.equal("main", input_calls[1].default)
+        end)
+
+        it("chains multiple inputs sequentially", function()
+            local call_count = 0
+            vim.ui.input = function(opts, callback)
+                call_count = call_count + 1
+                callback("val" .. call_count)
+            end
+
+            local result
+            input.resolve({ "input:A", "input:B" }, function(values)
+                result = values
+            end)
+
+            assert.are.equal(2, call_count)
+            assert.are.equal("val1", result["input:A"])
+            assert.are.equal("val2", result["input:B"])
+        end)
+
+        it("calls on_done(nil) when user cancels", function()
+            vim.ui.input = function(opts, callback)
+                callback(nil)
+            end
+
+            local result = "not_called"
+            input.resolve({ "input" }, function(values)
+                result = values
+            end)
+
+            assert.is_nil(result)
+        end)
+
+        it("aborts remaining inputs on cancel", function()
+            local call_count = 0
+            vim.ui.input = function(opts, callback)
+                call_count = call_count + 1
+                if call_count == 1 then
+                    callback("first")
+                else
+                    callback(nil)
+                end
+            end
+
+            local result = "not_called"
+            input.resolve({ "input:A", "input:B", "input:C" }, function(values)
+                result = values
+            end)
+
+            assert.are.equal(2, call_count)
+            assert.is_nil(result)
+        end)
+
+        it("calls on_done immediately for empty keys", function()
+            local result
+            input.resolve({}, function(values)
+                result = values
+            end)
+
+            assert.is_not_nil(result)
+            assert.are.equal(0, vim.tbl_count(result))
+        end)
+    end)
+end)

--- a/tests/helpers_send.lua
+++ b/tests/helpers_send.lua
@@ -11,6 +11,7 @@ local MODULES = {
 	"wiremux.picker",
 	"wiremux.utils.notify",
 	"wiremux.context",
+	"wiremux.context.input",
 }
 
 function M.setup()
@@ -39,6 +40,23 @@ function M.setup()
 				return text
 			end,
 		},
+		input = {
+			find = function()
+				return {}
+			end,
+			has_inputs = function()
+				return false
+			end,
+			replace = function(text)
+				return text
+			end,
+			resolve = function(keys, on_done)
+				on_done({})
+			end,
+			parse = function(key)
+				return "Input", nil
+			end,
+		},
 	}
 
 	helpers.register({
@@ -53,6 +71,7 @@ function M.setup()
 		["wiremux.picker"] = mocks.picker,
 		["wiremux.utils.notify"] = mocks.notify,
 		["wiremux.context"] = mocks.context,
+		["wiremux.context.input"] = mocks.input,
 	})
 
 	mocks.send = require("wiremux.action.send")

--- a/tests/send_input_spec.lua
+++ b/tests/send_input_spec.lua
@@ -1,0 +1,165 @@
+---@module 'luassert'
+
+local helpers = require("tests.helpers_send")
+
+describe("send with input placeholders", function()
+	local mocks
+
+	before_each(function()
+		mocks = helpers.setup()
+	end)
+
+	it("prompts user and sends expanded text", function()
+		local received_text
+
+		mocks.input.find = function(text)
+			return { "input:Branch" }
+		end
+		mocks.input.resolve = function(keys, on_done)
+			on_done({ ["input:Branch"] = "develop" })
+		end
+		mocks.input.replace = function(text, values)
+			return text:gsub("{input:Branch}", values["input:Branch"])
+		end
+
+		mocks.context.expand = function(text)
+			return text
+		end
+
+		mocks.backend.send = function(text)
+			received_text = text
+		end
+
+		mocks.action.run = function(opts, callbacks)
+			callbacks.on_targets({
+				{ id = "%1", kind = "pane", target = "test" },
+			}, {})
+		end
+
+		mocks.send.send("git checkout {input:Branch}")
+
+		assert.are.equal("git checkout develop", received_text)
+	end)
+
+	it("aborts send when user cancels input", function()
+		local send_called = false
+
+		mocks.input.find = function()
+			return { "input" }
+		end
+		mocks.input.resolve = function(keys, on_done)
+			on_done(nil)
+		end
+
+		mocks.backend.send = function()
+			send_called = true
+		end
+
+		mocks.action.run = function(opts, callbacks)
+			callbacks.on_targets({
+				{ id = "%1", kind = "pane", target = "test" },
+			}, {})
+		end
+
+		mocks.send.send("echo {input}")
+
+		assert.is_false(send_called)
+	end)
+
+	it("expands sync placeholders before input resolution", function()
+		local received_text
+		local expand_order = {}
+
+		mocks.context.expand = function(text)
+			table.insert(expand_order, "expand")
+			return text:gsub("{file}", "/path/to/file.lua")
+		end
+
+		mocks.input.find = function(text)
+			table.insert(expand_order, "find")
+			return { "input:Name" }
+		end
+		mocks.input.resolve = function(keys, on_done)
+			table.insert(expand_order, "resolve")
+			on_done({ ["input:Name"] = "world" })
+		end
+		mocks.input.replace = function(text, values)
+			return text:gsub("{input:Name}", values["input:Name"])
+		end
+
+		mocks.backend.send = function(text)
+			received_text = text
+		end
+
+		mocks.action.run = function(opts, callbacks)
+			callbacks.on_targets({
+				{ id = "%1", kind = "pane", target = "test" },
+			}, {})
+		end
+
+		mocks.send.send("echo {input:Name} in {file}")
+
+		assert.are.equal("echo world in /path/to/file.lua", received_text)
+		-- Verify ordering: expand runs before input find/resolve
+		assert.are.same({ "expand", "find", "resolve" }, expand_order)
+	end)
+
+	it("skips input resolution for text without input placeholders", function()
+		local resolve_called = false
+
+		mocks.input.resolve = function()
+			resolve_called = true
+		end
+
+		local received_text
+
+		mocks.backend.send = function(text)
+			received_text = text
+		end
+
+		mocks.action.run = function(opts, callbacks)
+			callbacks.on_targets({
+				{ id = "%1", kind = "pane", target = "test" },
+			}, {})
+		end
+
+		mocks.send.send("plain text")
+
+		assert.is_false(resolve_called)
+		assert.are.equal("plain text", received_text)
+	end)
+
+	it("preserves {selection} when mixed with {input}", function()
+		local received_text
+
+		-- Simulate: expand resolves {selection} but leaves {input:Name} untouched
+		-- Bare {input} is skipped explicitly in context.expand
+		mocks.context.expand = function(text)
+			return text:gsub("{selection}", "selected text")
+		end
+
+		mocks.input.find = function(text)
+			return { "input:Name" }
+		end
+		mocks.input.resolve = function(keys, on_done)
+			on_done({ ["input:Name"] = "value" })
+		end
+		mocks.input.replace = function(text, values)
+			return text:gsub("{input:Name}", values["input:Name"])
+		end
+
+		mocks.backend.send = function(text)
+			received_text = text
+		end
+
+		mocks.action.run = function(opts, callbacks)
+			callbacks.on_targets({
+				{ id = "%1", kind = "pane", target = "test" },
+			}, {})
+		end
+
+		mocks.send.send("echo {selection} {input:Name}")
+
+		assert.are.equal("echo selected text value", received_text)
+	end)
+end)


### PR DESCRIPTION
Hello, I like this project. Good job. Because of that, I've thought about a little contribution. I've implemented a feature that will improve my own workflow as a user.

It's a complete implementation with tests and docs, but please consider this as a proposition or proof of concept for a change. I'm willing to change or adjust something in this approach.

## What does this PR change?
This contribution introduces the `{input}` placeholder, which interactively asks the user for a value via `vim.ui.input()`.

For example:
```lua
require("wiremux").send("question:\n{input:Question}\n\ncontext:\n{this}")
```

It will display an input widget for the user with "Question" as a prompt. Text provided by the user will be used in place of the placeholder.

There is also the possibility to provide a default value:
```lua
require("wiremux").send("question:\n{input:Question:Explain this code.}\n\ncontext:\n{this}")
```

## Why?
Some placeholders (for example `{selection}`) won't work well when `wiremux.send()` is wrapped in `vim.ui.input()`.

This snippet will not work well:
```lua
vim.ui.input({ prompt = "Question" }, function(value)
    require("wiremux").send("question: " .. value .. "\ncontext:\n{selection}")
end)
```

`vim.ui.input()` is asynchronous. I'm using Snack's input. When the prompt window is created, Neovim's state is changed and the text selected in the buffer is lost. So wiremux can't expand the `{selection}` placeholder.

## Solution
A new `{input}` placeholder that prompts the user via `vim.ui.input()` at send time.

The placeholder expansion/resolving is done in this order:
1. **Sync phase** -- `context.expand()` resolves all standard placeholders (`{file}`, `{selection}`, etc.) immediately, capturing the current editor state before any UI interaction occurs.
2. **Async phase** -- `input.resolve()` then prompts the user for each `{input}` placeholder sequentially.

This guarantees that editor-state-dependent placeholders are captured while the state is still valid, regardless of what happens during user input.

### Syntax

The placeholder supports optional prompt labels and default values:

```
{input}                         -- prompt "Input", no default
{input:Search query}            -- prompt "Search query"
{input:Branch:main}             -- prompt "Branch", default "main"
{input:URL:http://example.com}  -- prompt "URL", default "http://example.com"
```

### Cancellation and deduplication

- Cancelling any prompt (returning `nil` from `vim.ui.input()`) aborts the entire send. No partial text is dispatched.
- Identical `{input}` expressions are deduplicated -- prompted once, substituted everywhere they appear.
- User-entered text is treated as literal. Placeholders typed into the prompt are not recursively expanded.

## Implementation details

### New module: `lua/wiremux/context/input.lua`

Self-contained module with four functions:

- `find(text)` -- extracts unique `{input...}` keys from text, preserving order of first appearance. Rejects false positives like `{input_var}` or `{input2}` by requiring either bare `"input"` or the `"input:"` prefix.
- `parse(key)` -- splits a key into prompt label and optional default value. The first colon after `input:` separates the prompt from the default, so defaults can contain colons (e.g. URLs).
- `replace(text, values)` -- substitutes resolved values back into text. Unresolved keys are left intact.
- `resolve(keys, on_done)` -- chains `vim.ui.input()` calls sequentially. Calls `on_done(values)` on completion or `on_done(nil)` on cancellation.

### Test coverage

- `tests/context_input_spec.lua` -- unit tests for `parse`, `find`, `has_inputs`, `replace`, and `resolve`, including some edge cases 
- `tests/send_input_spec.lua` -- integration tests for the send action, verifying resolution order, cancellation aborting send, etc.

## Usage examples

```lua
-- Prompt before sending a grep command
require("wiremux").send("grep -r '{input:Search query:TODO}' {file}")

-- Multiple prompts in one send
require("wiremux").send("git log --author='{input:Author}' --grep='{input:Grep pattern}'")

-- Mix with other context placeholders -- {selection} resolves first, then {input} prompts
require("wiremux").send("question:\n{input:Question}\n\ncontext:\n{this}")
```
